### PR TITLE
Include angular <4.0.0 as valid dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: angular_recaptcha
 description: Google Angular Recaptcha
-version: 0.0.5
+version: 0.0.6
 homepage: https://github.com/lejard-h/angular_recaptcha
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 environment:
   sdk: '>=1.19.0 <2.0.0'
 
 dependencies:
-  angular2: ">=2.2.0 <3.0.0"
+  angular2: ">=2.2.0 <4.0.0"
   js: ^0.6.0
 
 transformers:


### PR DESCRIPTION
From what I can see, angular 3.0.0 works fine with this library, so no need to exclude it.