### PR TITLE
Upgrade to angular 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.0.7
+
+- Upgraded to angular v4.0.0
+- Added Changelog

--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 ## How to use
 
 ### Add to pubspec.yaml
-`angular_recaptcha: ^0.0.5`
+
+```yaml
+angular_recaptcha: ^0.0.7
+# If you are still running angular `v2` or `v3`,
+# then you need to use: 
+# angular_recaptcha: "0.0.6"` 
+```
 
 then
 

--- a/lib/angular_recaptcha.dart
+++ b/lib/angular_recaptcha.dart
@@ -5,8 +5,8 @@
 library angular_recaptcha;
 
 import 'dart:html';
-import 'package:angular2/angular2.dart';
-import 'package:angular2/core.dart';
+import 'package:angular/angular.dart';
+import 'package:angular/core.dart';
 import 'package:js/js.dart';
 
 @JS('grecaptcha.render')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: angular_recaptcha
 description: Google Angular Recaptcha
-version: 0.0.6
+version: 0.0.7
 homepage: https://github.com/lejard-h/angular_recaptcha
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 environment:
-  sdk: '>=1.19.0 <2.0.0'
+  sdk: '>=1.24.0 <2.0.0'
 
 dependencies:
-  angular2: ">=2.2.0 <4.0.0"
+  angular: ^4.0.0-alpha
   js: ^0.6.0
 
 transformers:
-  - angular2
+  - angular


### PR DESCRIPTION
I also added a CHANGELOG.md in this PR.

Since angular 4 decided to go back to the `angular` package (instead of the confusing `angular2: 4.0.0` versioning), simply including the latest `4.0.0` version in the dependency was not possible.

Angular 4 also has a dart `1.24.0` requirement, that's why I bumped it for this package as well.