### PR TITLE
Update recaptcha API script URL

### DIFF
--- a/lib/angular_recaptcha.dart
+++ b/lib/angular_recaptcha.dart
@@ -190,7 +190,7 @@ Element _script;
 
 FutureOr<T> _safeApiCall<T>(_VoidCallback<T> call) async {
   await loadScript(
-      "https://www.google.com/recaptcha/api.js?onload=render=explicit",
+      "https://www.google.com/recaptcha/api.js?render=explicit",
       isAsync: true,
       isDefer: true,
       id: "grecaptcha-jssdk");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: angular_recaptcha
 description: Google Angular Recaptcha
-version: 0.1.1
+version: 0.1.2
 homepage: https://github.com/lejard-h/angular_recaptcha
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 environment:


### PR DESCRIPTION
Change `https://www.google.com/recaptcha/api.js?onload=render=explicit` to 
`https://www.google.com/recaptcha/api.js?render=explicit` 

First URL is causing 400 errors.

Also I feel like we should make this version available on pub.dartlang.org as well.