### PR TITLE
Remove v2 from URL check

### DIFF
--- a/lib/angular_recaptcha.dart
+++ b/lib/angular_recaptcha.dart
@@ -195,7 +195,7 @@ FutureOr<T> _safeApiCall<T>(_VoidCallback<T> call) async {
     _script = scripts.where((s) => s is ScriptElement).firstWhere(
         (s) => (s as ScriptElement)
             .src
-            .startsWith("https://www.gstatic.com/recaptcha/api2/"),
+            .startsWith("https://www.gstatic.com/recaptcha/"),
         orElse: () => null);
     if (_script == null) return null;
   }


### PR DESCRIPTION
Google seems to have changed the URL for the recaptcha, so the URL match check started failing out of the blue.

The new URL is something like: `https://www.gstatic.com/recaptcha/releases/abc123....3210/recaptcha__en.js`

I don't know the reason behind the specific check for `api2` but removing it solves the problem.